### PR TITLE
add instruction to store plugin type when validatin a plugin

### DIFF
--- a/src/obj.c
+++ b/src/obj.c
@@ -177,6 +177,7 @@ ac_plugin_validate(struct ac_plugin *plugin)
 					return false;
 				} else {
 					ac_printf("Plugin type: %d\n", plugin_type);
+					memcpy(&plugin->type, &plugin_type, sizeof(ac_plugin_type_t));
 					sym_count++;
 					continue;
 				}


### PR DESCRIPTION
Currently, when validating a plugin type the actual value is not stored in the plugin entity:

```
if (strncmp(sym.name, "plugin_type", 11) == 0) {
    if (ac_plugin_validate_type(&plugin->elfobj,
				sym.value, &plugin_type) == false) {
        ac_printf("Invalid plugin type: %d\n", plugin_type);
        return false;
    } else {
        ac_printf("Plugin type: %d\n", plugin_type);
        sym_count++;
        continue;
    }
}
```

Then, when processing pre/post-plugins the type validation (current->type) fails due to uninitialized values:

```
if (current->type != AC_PLUGIN_PRE_HANDLER)
```

The proposed fix stores the plugin_type value into plugin->type when a plugin is validated and a valid plugin type is found.
