### PR TITLE
Experimental plugin for detecting extended sections

### DIFF
--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -1,5 +1,7 @@
 all:
 	gcc -c -fPIC golang.c
 	gcc -shared -o golang.plugin.so golang.o /opt/elfmaster/lib/libelfmaster.a
+	gcc -shared -o extended_section.plugin.so extended_section.o /opt/elfmaster/lib/libelfmaster.a
 clean:
 	rm -f golang.plugin.so golang.o
+	rm -f extended_section.plugin.so extended_section.o

--- a/plugins/extended_section.c
+++ b/plugins/extended_section.c
@@ -1,0 +1,114 @@
+/*
+ *
+ * extended_section.c - plugin for detecting extended sections (altered padding bytes)
+ * by isra - isra _replace_this_by_@ fastmail.net
+ *
+ */
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <elf.h>
+#include <sys/types.h>
+#include <search.h>
+#include <sys/time.h>
+#include "../include/arcana.h"
+#include "../include/plugin.h"
+#include "/opt/elfmaster/include/libelfmaster.h"
+
+const ac_plugin_type_t plugin_type = 0;
+ac_plugin_name_t plugin_name = "extended section plugin v1";
+
+bool
+init_plugin_detect_extended_section(arcana_ctx_t *ac, struct obj_struct *obj, void **arg)
+{
+	(void)arg;
+	uint8_t *ptr, read_init, read_fini;
+	uint64_t i, init_last_byte, fini_last_byte;
+
+	elfobj_t *elfobj = obj->elfobj;
+	/* executable sections that are most likely to be extended */
+	struct elf_section init, fini;
+	/* contiguous sections to .init and .fini */
+	struct elf_section plt, rodata;
+
+	read_init = 0;
+	read_fini = 0;
+
+	if(elf_section_by_name(elfobj, ".init", &init) != NULL) {
+		if(elf_section_by_name(elfobj, ".plt", &plt) != NULL) {
+			printf("Found .init and .plt sections.\n");
+			read_init = 1;
+		}
+	}
+
+	if(elf_section_by_name(elfobj, ".fini", &fini) != NULL) {
+		if(elf_section_by_name(elfobj, ".rodata", &rodata) != NULL) {
+			printf("Found .fini and .rodata sections.\n");
+			read_fini = 1;
+		}
+	}
+
+	if(!read_init && !read_fini) {
+		printf("Couldn't read .init or .fini sections\n");
+		return false;
+	}
+
+	/* last non-zero byte after the end of .init or .fini */
+	init_last_byte = 0;
+
+	/* loop from the end of .init to the start of .plt */
+	for(i = init.offset + (uint64_t)init.size; i < plt.offset; i++) {
+		ptr = elf_offset_pointer(elfobj, i);
+		if(*ptr != 0) {
+			/* save the last non-zero byte */
+			init_last_byte = i;
+		}
+	}
+
+	/* last non-zero byte after the end of .init or .fini */
+	fini_last_byte = 0;
+
+	/* loop from the end of .fini to the start of .rodata */
+	for(i = fini.offset + (uint64_t)fini.size; i < rodata.offset; i++) {
+		ptr = elf_offset_pointer(elfobj, i);
+		if(*ptr != 0) {
+			/* save the last non-zero byte */
+			fini_last_byte = i;
+		}
+	}
+
+	if(init_last_byte != 0) {
+		/* padding bytes after .init section have been altered */
+		obj->verdict = AC_VERDICT_INFECTED;
+		printf("Extension of .init section detected\n");
+		printf("End of section at offset: %x\n", init.offset + (uint64_t)init.size );
+		printf("Last padding byte altered at offset: %x\n", init_last_byte);
+	}
+
+	if(fini_last_byte != 0) {
+		/* padding bytes after .fini section have been altered */
+		obj->verdict = AC_VERDICT_INFECTED;
+		printf("Extension of .fini section detected\n");
+		printf("End of section at offset: %x\n", fini.offset + (uint64_t)fini.size );
+		printf("Last padding byte altered at offset: %x\n", fini_last_byte);
+	} 
+
+	if(init_last_byte || fini_last_byte) {
+		return true;
+	}
+
+	if(!init_last_byte && !fini_last_byte) {
+		printf("Extension of .init or .fini sections not detected\n");
+		return false;
+	}
+}
+
+void exit_plugin_detect_extended_section(arcana_ctx_t *ac, struct obj_struct *obj, void **arg)
+{
+	(arcana_ctx_t *)ac;
+	(void)arg;
+	(struct obj_struct *)obj;
+
+	return;
+}


### PR DESCRIPTION
I've created a plugin for detecting executable sections that are most likely to be extended (padding bytes altered) for injecting parasite code: .init and .fini. This is based on the fact that the padding bytes of such sections could be altered together to run parasite code without modifying the ELF entry point or other headers. In short, the proposed plugin does the following:

- Find .init and .fini together with its contiguous sections (.plt and .rodata respectively).
- Read padding bytes of .init and .fini by looping from the end of each section until the start of the following section.
- Save the last non-zero byte found in the padding bytes areas. 
- If the last non-zero byte exists, then the padding bytes area has been altered and the verdict is changed to AC_VERDICT_INFECTED.

This plugin is based on https://tmpout.sh/3/30.html and another paper currently on review.